### PR TITLE
fix(input): add cursor position reset after closing prompt

### DIFF
--- a/lua/microscope/ui/input.lua
+++ b/lua/microscope/ui/input.lua
@@ -14,6 +14,9 @@ end
 local function on_close(self)
   events.clear_module(self)
   self:close()
+
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  vim.api.nvim_win_set_cursor(0, { cursor[1], cursor[2] + 1 })
 end
 
 function input:text()


### PR DESCRIPTION
In this PR I fixed the cursor position after closing the prompt window.

Closes #2 